### PR TITLE
Exclude unit test files from docs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --watchAll=false",
-    "docs": "npx typedoc --out docs src",
+    "docs": "npx typedoc --exclude src/**/*.test.tsx --out docs src",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json,.css.scss,.md src --color",
     "format": "prettier --write src/**/*.{ts,tsx,scss,css,json}"


### PR DESCRIPTION
The docs script is currently trying to build documentation for all TypeScript files which includes the unit test files. We don't need docs for these files, and they don't contain 100% proper TS so they cause the docs builds to fail. This PR excludes all test files from the documentation.