### PR TITLE
Change documentation deploy branch to gh-pages.

### DIFF
--- a/.github/workflows/docAction.yml
+++ b/.github/workflows/docAction.yml
@@ -21,5 +21,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: master
+          BRANCH: gh-pages
           FOLDER: docs


### PR DESCRIPTION
I finally figured out the issue with our documentation deployment. It's been trying to deploy built docs artifacts to the master branch, however this master branch requires PR approval before anything can be merged in which the doc deploy action does not have. To remedy this, I've created a new branch called `gh-pages` which will hold the doc assets.